### PR TITLE
Refine "What is GitOps?" section + lint/cosmetic changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A curated list for awesome GitOps resources inspired by [@sindresorhus' awesome]
 
 ## What is GitOps?
 
-GitOps is a way to do [Continuous Delivery](https://en.wikipedia.org/wiki/Continuous_delivery). It works by using Git as a single source of truth for declarative infrastructure and applications. With Git at the center of your delivery pipelines, developers can make pull requests to accelerate and simplify application deployments and operations tasks to Kubernetes.
+GitOps is a way to do [Continuous Delivery](https://en.wikipedia.org/wiki/Continuous_delivery). It works by using [Git](https://git-scm.com/) as a single source of truth for declarative infrastructure and applications. With Git at the center of your delivery pipelines, developers can make pull requests to accelerate and simplify application deployments and operations tasks to Kubernetes.
 
 ## Why is GitOps awesome?
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A curated list for awesome GitOps resources inspired by [@sindresorhus' awesome]
 
 ## What is GitOps?
 
-GitOps is a way to do [Continuous Delivery](https://en.wikipedia.org/wiki/Continuous_delivery). It works by using [Git](https://git-scm.com/) as a single source of truth for [declarative infrastructure and applications](https://en.wikipedia.org/wiki/Infrastructure_as_code). With Git at the center of your delivery pipelines, developers can make pull requests to accelerate and simplify application deployments and operations tasks to Kubernetes.
+GitOps is a way to do [Continuous Delivery](https://en.wikipedia.org/wiki/Continuous_delivery). It works by using [Git](https://git-scm.com/) as a single source of truth for [declarative infrastructure and applications](https://en.wikipedia.org/wiki/Infrastructure_as_code), together with tools ensuring the actual state of infrastructure and applications converges towards the target state declared in Git. With Git at the center of your delivery pipelines, developers can make pull requests to accelerate and simplify application deployments and operations tasks to Kubernetes.
 
 ## Why is GitOps awesome?
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A curated list for awesome GitOps resources inspired by [@sindresorhus' awesome]
 
 ## What is GitOps?
 
-GitOps is a way to do [Continuous Delivery](https://en.wikipedia.org/wiki/Continuous_delivery). It works by using [Git](https://git-scm.com/) as a single source of truth for declarative infrastructure and applications. With Git at the center of your delivery pipelines, developers can make pull requests to accelerate and simplify application deployments and operations tasks to Kubernetes.
+GitOps is a way to do [Continuous Delivery](https://en.wikipedia.org/wiki/Continuous_delivery). It works by using [Git](https://git-scm.com/) as a single source of truth for [declarative infrastructure and applications](https://en.wikipedia.org/wiki/Infrastructure_as_code). With Git at the center of your delivery pipelines, developers can make pull requests to accelerate and simplify application deployments and operations tasks to Kubernetes.
 
 ## Why is GitOps awesome?
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A curated list for awesome GitOps resources inspired by [@sindresorhus' awesome]
 
 ## What is GitOps?
 
-GitOps is a way to do [Continuous Delivery](https://en.wikipedia.org/wiki/Continuous_delivery). It works by using [Git](https://git-scm.com/) as a single source of truth for [declarative infrastructure and applications](https://en.wikipedia.org/wiki/Infrastructure_as_code), together with tools ensuring the actual state of infrastructure and applications converges towards the target state declared in Git. With Git at the center of your delivery pipelines, developers can make pull requests to accelerate and simplify application deployments and operations tasks to Kubernetes.
+GitOps is a way to do [Continuous Delivery](https://en.wikipedia.org/wiki/Continuous_delivery). It works by using [Git](https://git-scm.com/) as a single source of truth for [declarative infrastructure and applications](https://en.wikipedia.org/wiki/Infrastructure_as_code), together with tools ensuring the actual state of infrastructure and applications converges towards the target state declared in Git. With Git at the center of your delivery pipelines, developers can make pull requests to accelerate and simplify application deployments and operations tasks to your infrastructure or container-orchestration system (e.g. [Kubernetes](https://kubernetes.io/)).
 
 ## Why is GitOps awesome?
 

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ A curated list for awesome GitOps resources inspired by [@sindresorhus' awesome]
 GitOps is a way to do [Continuous Delivery](https://en.wikipedia.org/wiki/Continuous_delivery). It works by using [Git](https://git-scm.com/) as a single source of truth for [declarative infrastructure and applications](https://en.wikipedia.org/wiki/Infrastructure_as_code), together with tools ensuring the actual state of infrastructure and applications converges towards the target state declared in Git. With Git at the center of your delivery pipelines, developers can make pull requests to accelerate and simplify application deployments and operations tasks to your infrastructure or container-orchestration system (e.g. [Kubernetes](https://kubernetes.io/)).
 
 ## Why is GitOps awesome?
-
+ 
 It [increases developer productivity](https://www.weave.works/technologies/gitops/#key-benefits), [enhances developer experience](https://www.weave.works/technologies/gitops/#key-benefits), [improves stability](https://www.weave.works/technologies/gitops/#key-benefits), all will having [higher reliability](https://www.weave.works/technologies/gitops/#key-benefits), [higher consistency](https://www.weave.works/technologies/gitops/#key-benefits) and [stronger security guarantees](https://www.weave.works/technologies/gitops/#key-benefits).
 
-- [Awesome GitOps](#awesome-gitops)
-	- [Tools](#tools)
-	- [Tutorials](#tutorials)
+- [Awesome-GitOps](#Awesome-GitOps)
+  - [Tools](#Tools)
+  - [Tutorials](#Tutorials)
 
 ## Background
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A curated list for awesome GitOps resources inspired by [@sindresorhus' awesome]
 
 ## What is GitOps?
 
-GitOps is a way to do Continuous Delivery. It works by using Git as a single source of truth for declarative infrastructure and applications. With Git at the center of your delivery pipelines, developers can make pull requests to accelerate and simplify application deployments and operations tasks to Kubernetes.
+GitOps is a way to do [Continuous Delivery](https://en.wikipedia.org/wiki/Continuous_delivery). It works by using Git as a single source of truth for declarative infrastructure and applications. With Git at the center of your delivery pipelines, developers can make pull requests to accelerate and simplify application deployments and operations tasks to Kubernetes.
 
 ## Why is GitOps awesome?
 

--- a/README.md
+++ b/README.md
@@ -17,16 +17,17 @@ It [increases developer productivity](https://www.weave.works/technologies/gitop
 	- [Tutorials](#tutorials)
 
 ## Background
-* [Operations by pull request](https://www.weave.works/blog/gitops-operations-by-pull-request) - a blog entry about how GitOps came about at Weaveworks
+
+- [Operations by pull request](https://www.weave.works/blog/gitops-operations-by-pull-request) - a blog entry about how GitOps came about at Weaveworks
 
 ## Tools
 
-* [Flux](https://github.com/weaveworks/flux) - The GitOps Kubernetes operator
-* [Flagger](https://github.com/weaveworks/flagger) - Progressive delivery Kubernetes operator (Canary, A/B testing and Blue/Green deployments automation)
-* [Weave Cloud](https://www.weave.works/product/cloud/) - GitOps experience, workflows and dashboard for your cluster(s) (commercial product from Weaveworks)
+- [Flux](https://github.com/weaveworks/flux) - The GitOps Kubernetes operator
+- [Flagger](https://github.com/weaveworks/flagger) - Progressive delivery Kubernetes operator (Canary, A/B testing and Blue/Green deployments automation)
+- [Weave Cloud](https://www.weave.works/product/cloud/) - GitOps experience, workflows and dashboard for your cluster(s) (commercial product from Weaveworks)
 
 ## Tutorials
 
-* [Managing Helm releases the GitOps way](https://github.com/fluxcd/helm-operator-get-started) - Flux and Helm Operator tutorial
-* [Automating Istio canary deployments with GitOps](https://github.com/stefanprodan/gitops-istio) - Progressive Delivery tutorial with Flagger, Flux, Helm Operator and Istio
-* [Managing a multi-tenant cluster with GitOps](https://github.com/stefanprodan/fluxcd-multi-tenancy) - Flux and Kustomize tutorial
+- [Managing Helm releases the GitOps way](https://github.com/fluxcd/helm-operator-get-started) - Flux and Helm Operator tutorial
+- [Automating Istio canary deployments with GitOps](https://github.com/stefanprodan/gitops-istio) - Progressive Delivery tutorial with Flagger, Flux, Helm Operator and Istio
+- [Managing a multi-tenant cluster with GitOps](https://github.com/stefanprodan/fluxcd-multi-tenancy) - Flux and Kustomize tutorial


### PR DESCRIPTION
**Changelog**:
- Added a few links to definition, to help with context and newcomers who could be "yak shaving".
- What is GitOps
  - mentioned tools required for convergence of state,
  - generalised GitOps to other systems than Kubernetes.
- Fixed a few markdownlint warnings. [1]
- Updated the table of contents. [2]

[1]: I didn't fix all warnings raised with default settings (e.g. line length, etc.), just unordered lists (`*` -> `-` and spacing). Also, should we [markdownlint](https://github.com/markdownlint/markdownlint) this awesome list in CI?
[2]: Should we have a tool checking/doing this automatically in CI?