### PR TITLE
Lint markdown and ensure table-of-content is up-to-date

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,22 @@
+version: 2
+
+workflows:
+  version: 2
+  any-commit:
+    jobs:
+      - lint
+
+jobs:
+  lint:
+    docker: # run the steps with Docker
+      - image: circleci/node:12.6 # ...with this image as the primary container; this is where all `steps` will run
+    steps:
+      - checkout
+      - run:
+          name: install-markdownlint
+          command: |
+            sudo npm install -g markdownlint-cli
+            markdownlint --version
+      - run:
+          name: lint
+          command: markdownlint .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,5 +18,15 @@ jobs:
             sudo npm install -g markdownlint-cli
             markdownlint --version
       - run:
+          name: install-markdown-toc
+          command: |
+            sudo npm install -g markdown-toc
+      - run:
           name: lint
-          command: markdownlint .
+          command: |
+            markdownlint .
+            markdown-toc --bullets="-" -i README.md
+            # Fail the build if markdown-toc generated changes in README.md:
+            git diff --exit-code || ( echo -e "${MARKDOWN_TOC_MESSAGE}" ; false )
+          environment:
+            MARKDOWN_TOC_MESSAGE: '\nPlease update the table of content using:\n  markdown-toc --bullets="-" -i README.md\nthen commit the changes, and push to this branch again.\n'

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,9 @@
+{
+  "default": true,
+
+  "line_length": false,
+  "no-bare-urls": false,
+
+  "comment": "Ignore errors like MD026/no-trailing-punctuation Trailing punctuation in heading [Punctuation: '?'] in README.md's title",
+  "no-trailing-punctuation": false
+}

--- a/README.md
+++ b/README.md
@@ -1,24 +1,29 @@
-# Awesome-GitOps
+# Awesome-GitOps <!-- omit in toc -->
 
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 
 A curated list for awesome GitOps resources inspired by [@sindresorhus' awesome](https://github.com/sindresorhus/awesome)
 
-## What is GitOps?
+## What is GitOps? <!-- omit in toc -->
 
 GitOps is a way to do [Continuous Delivery](https://en.wikipedia.org/wiki/Continuous_delivery). It works by using [Git](https://git-scm.com/) as a single source of truth for [declarative infrastructure and applications](https://en.wikipedia.org/wiki/Infrastructure_as_code), together with tools ensuring the actual state of infrastructure and applications converges towards the target state declared in Git. With Git at the center of your delivery pipelines, developers can make pull requests to accelerate and simplify application deployments and operations tasks to your infrastructure or container-orchestration system (e.g. [Kubernetes](https://kubernetes.io/)).
 
-## Why is GitOps awesome?
+## Why is GitOps awesome? <!-- omit in toc -->
 
 It [increases developer productivity](https://www.weave.works/technologies/gitops/#key-benefits), [enhances developer experience](https://www.weave.works/technologies/gitops/#key-benefits), [improves stability](https://www.weave.works/technologies/gitops/#key-benefits), all while having [higher reliability](https://www.weave.works/technologies/gitops/#key-benefits), [higher consistency](https://www.weave.works/technologies/gitops/#key-benefits) and [stronger security guarantees](https://www.weave.works/technologies/gitops/#key-benefits).
 
 Modern software development practices _assume_ support for reviewing changes, tracking history, comparing versions, and rolling back bad updates; GitOps applies the same tooling and engineering perspective to managing the systems that deliver direct business value to users and customers.
 
-- [Awesome-GitOps](#Awesome-GitOps)
-  - [Tools](#Tools)
-  - [Ancillary Tools](#Ancillary-Tools)
-  - [Tutorials](#Tutorials)
-  - [Community](#Community)
+<!-- toc -->
+
+- [Background](#background)
+- [Tools](#tools)
+- [Ancillary Tools](#ancillary-tools)
+  - [Secrets](#secrets)
+- [Tutorials](#tutorials)
+- [Community](#community)
+
+<!-- tocstop -->
 
 ## Background
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Modern software development practices _assume_ support for reviewing changes, tr
 
 ### Secrets
 
-- [Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets) - One-way encrypted Secrets 
+- [Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets) - One-way encrypted Secrets
 - [SOPS](https://github.com/mozilla/sops) - Secrets OPerationS
 
 ## Tutorials


### PR DESCRIPTION
**Changelog**:

- Add linting of all markdown files via [`markdownlint`](https://github.com/DavidAnson/markdownlint-cli).
- Fix `README.md` to pass linting.
- Add automated check to ensure `README.md`'s table of content is up-to-date via [`markdown-toc`](https://github.com/jonschlinkert/markdown-toc). Titles located above the table of content are not taken into account, in order to avoid unnecessary "noise".

**Testing**:

- `markdownlint` failures tested in [this build](https://circleci.com/gh/weaveworks/awesome-gitops/18).
- `markdown-toc` failures tested in [this build](https://circleci.com/gh/weaveworks/awesome-gitops/16).

**N.B.**:

For Visual Studio Code users, [this plugin](https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one)
performs similar checks and updates the table of content on save. (TOC links are currently NOT lowercased. [This issue](https://github.com/yzhang-gh/vscode-markdown/issues/476) should fix it soon though.)