### PR TITLE
Added kubestack to tool list

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Modern software development practices _assume_ support for reviewing changes, tr
 - [Faros](https://github.com/pusher/faros) - CRD based GitOps controller
 - [Gitkube](https://gitkube.sh/) - Build and deploy docker images to Kubernetes using git push
 - [Jenkins X](https://jenkins-x.io/) - a CI/CD platform for Kubernetes that provides pipeline automation, built-in GitOps and preview environments
+- [KubeStack](https://www.kubestack.com/) - GitOps framework using Terraform for Cloud Kubernetes distros (AKS, GKE, and EKS) with CI/CD examples for common tools
 - [Weave Cloud](https://www.weave.works/product/cloud/) - GitOps experience, workflows and dashboard for your cluster(s) (commercial product from Weaveworks)
 - [Werf](https://werf.io) - GitOps tool with advanced features to build images and deploy them to Kubernetes (integrates with any existing CI system)
 


### PR DESCRIPTION
# Changelog

Added KubeStack to the list of tools. KubeStack, in essence, is a framework that sets up production-grade Kubernetes on Azure, Amazon or Google. It comes with some example pipeline files to setup on Jenkins, Gitlab, GitHub.