### PR TITLE
README: Add Carvel to "Tools"

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Modern software development practices _assume_ support for reviewing changes, tr
 - [ArgoCD](https://github.com/argoproj/argo-cd) - Declarative continuous deployment for Kubernetes
 - [Atlantis](https://www.runatlantis.io/) - Terraform pull request automation
 - [Autoapply](https://github.com/autoapply/autoapply) - Automatically apply changes from a Git repository to a Kubernetes cluster
+- [Carvel](https://carvel.dev) — Tool suite for building, packaging, and managing software on Kubernetes in a GitOps way
 - [CloudBees Rollout](https://rollout.io/) - Feature Flag as-a-Service that leverages GitOps & Config-as-Code (commercial product from CloudBees)
 - [Flux](https://github.com/fluxcd/flux2) - Open and extensible continuous delivery solution for Kubernetes. Powered by GitOps Toolkit
 - [Helm Operator](https://github.com/fluxcd/helm-operator) - Automates Helm Chart releases in a GitOps manner


### PR DESCRIPTION
Carvel's kapp-controller is a Kubernetes operator that syncs a K8s cluster from multiple kinds of sources, including git (fetch, template, deploy). As of September 2022, Carvel is a CNCF project.