### PR TITLE
remove GitKube from list

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ Modern software development practices _assume_ support for reviewing changes, tr
 - [Flagger](https://github.com/weaveworks/flagger) - Progressive delivery Kubernetes operator (Canary, A/B testing and Blue/Green deployments automation)
 - [Ignite](https://github.com/weaveworks/ignite) - A Virtual Machine manager with a container UX and built-in GitOps
 - [Faros](https://github.com/pusher/faros) - CRD based GitOps controller
-- [Gitkube](https://gitkube.sh/) - Build and deploy docker images to Kubernetes using git push
 - [Jenkins X](https://jenkins-x.io/) - a CI/CD platform for Kubernetes that provides pipeline automation, built-in GitOps and preview environments
 - [KubeStack](https://www.kubestack.com/) - GitOps framework using Terraform for Cloud Kubernetes distros (AKS, GKE, and EKS) with CI/CD examples for common tools
 - [Sceptre](https://github.com/Sceptre/sceptre) - Sceptre is a tool to drive AWS CloudFormation as part of a CI/CD pipeline by using Hooks


### PR DESCRIPTION
The website doesn't exist, anymore, and the domain name has apparently been taken over by another entity. Looking at the [GitKube GitHub repo](https://github.com/hasura/gitkube) it looks like the project is abandoned.

closes #56