### PR TITLE
Add Proxmox-GitOps

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Modern software development practices _assume_ support for reviewing changes, tr
 - [Jenkins X](https://jenkins-x.io/) - a CI/CD platform for Kubernetes that provides pipeline automation, built-in GitOps and preview environments
 - [Kubefirst](https://github.com/kubefirst/kubefirst) - Fully-automated OSS delivery & infrastructure management gitops platforms
 - [KubeStack](https://www.kubestack.com/) - GitOps framework using Terraform for Cloud Kubernetes distros (AKS, GKE, and EKS) with CI/CD examples for common tools
+- [Proxmox-GitOps](https://github.com/stevius10/Proxmox-GitOps) - Self-contained GitOps framework for LXC-based container automation on Proxmox VE.
 - [Sceptre](https://github.com/Sceptre/sceptre) - Sceptre is a tool to drive AWS CloudFormation as part of a CI/CD pipeline by using Hooks
 - [Weave GitOps OSS](https://github.com/weaveworks/weave-gitops) - Weave GitOps is a simple open source developer platform for people who want cloud native applications, without needing Kubernetes expertise.
 - [Weave GitOps Enterprise](https://www.weave.works/product/gitops-enterprise/) - Weave GitOps Enterprise is a continuous operations product that makes it easy to deploy and manage Kubernetes clusters and applications at scale in any environment. (commercial product from Weaveworks)


### PR DESCRIPTION
Hello,

I would like to propose adding my community open-source project, **Proxmox-GitOps**, to the `Tools` section.



> Proxmox-GitOps: Self-Contained Meta-Framework for Recursive Linux Container Automation as Composite IaC Monorepository.
> - **Link:** `https://github.com/stevius10/Proxmox-GitOps`

Conceptually, this project applies declarative GitOps principles championed by tools like **Flux**, but targets **Proxmox VE** and **LXC** instead of Kubernetes. It uses a self-contained composite monorepo and manages the complete lifecycle of LXC containers via the built-in Git platform.

I believe this is could be valuable because it demonstrates the flexibility of GitOps and provides a solution for automating infrastructure directly on Proxmox, described declaratively as Infrastructure-as-Code. 

I think the concept itself, a recursively resolved monorepo, could be interesting as well: Encapsulate infrastructure libraries with which the platform builds itself, creates an operational pattern and working base in recursive scenario, which benefits of the functional programming style resulting in stable and reproducible behaviour. 

In line with the contribution guidelines:
- The entry is added in alphabetical order.
- It follows the specified format.
- This PR contains only this single suggestion.

Thank you for your consideration!
