### PR TITLE
add argocd-backup-s3 entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Modern software development practices _assume_ support for reviewing changes, tr
 - [PipeCD](https://pipecd.dev/) - Continuous Delivery for Declarative Kubernetes, Serverless and Infrastructure Applications
 - [Grant.rs](https://github.com/duyet/grant.rs) - Manage Redshift/Postgres privileges in GitOps style
 - [Gimlet](https://github.com/gimlet-io/gimlet) - The Flux-based Internal Developer Platform
+- [argocd-backup-s3](https://github.com/oguzhan-yilmaz/argocd-backup-s3/) -  Kubernetes CronJob to backup ArgoCD with `argocd admin export` cmd and upload to S3 compatible storage 
 
 ## Ancillary Tools
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Modern software development practices _assume_ support for reviewing changes, tr
 - [PipeCD](https://pipecd.dev/) - Continuous Delivery for Declarative Kubernetes, Serverless and Infrastructure Applications
 - [Grant.rs](https://github.com/duyet/grant.rs) - Manage Redshift/Postgres privileges in GitOps style
 - [Gimlet](https://github.com/gimlet-io/gimlet) - The Flux-based Internal Developer Platform
-- [argocd-backup-s3](https://github.com/oguzhan-yilmaz/argocd-backup-s3/) -  Kubernetes CronJob to backup ArgoCD with `argocd admin export` cmd and upload to S3 compatible storage 
+- [argocd-backup-s3](https://github.com/oguzhan-yilmaz/argocd-backup-s3/) -  Kubernetes CronJob to backup ArgoCD with `argocd admin export` cmd and upload to S3 compatible storage
 
 ## Ancillary Tools
 


### PR DESCRIPTION
Hey, i wrote a kubernetes cronjob to backup argocd and published it as a helm chart. I've added it to the list.