### PR TITLE
Add KubeStellar Console to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Modern software development practices _assume_ support for reviewing changes, tr
 - [Faros](https://github.com/pusher/faros) - CRD based GitOps controller
 - [Jenkins X](https://jenkins-x.io/) - a CI/CD platform for Kubernetes that provides pipeline automation, built-in GitOps and preview environments
 - [Kubefirst](https://github.com/kubefirst/kubefirst) - Fully-automated OSS delivery & infrastructure management gitops platforms
+- [KubeStellar Console](https://github.com/kubestellar/console) - Multi-cluster Kubernetes dashboard with GitOps-driven deployment visibility across edge and cloud clusters
 - [KubeStack](https://www.kubestack.com/) - GitOps framework using Terraform for Cloud Kubernetes distros (AKS, GKE, and EKS) with CI/CD examples for common tools
 - [Proxmox-GitOps](https://github.com/stevius10/Proxmox-GitOps) - Self-contained GitOps framework for LXC-based container automation on Proxmox VE.
 - [Sceptre](https://github.com/Sceptre/sceptre) - Sceptre is a tool to drive AWS CloudFormation as part of a CI/CD pipeline by using Hooks


### PR DESCRIPTION
Add [KubeStellar Console](https://github.com/kubestellar/console) to the Tools section.

KubeStellar Console is a multi-cluster Kubernetes dashboard with GitOps-driven deployment visibility across edge and cloud clusters. It integrates with Argo CD and Flux for real-time observability of GitOps workflows across multiple clusters.

- **Open source**: [github.com/kubestellar/console](https://github.com/kubestellar/console)
- **CNCF Sandbox project**
- **Placement**: Tools section, alphabetical order between Kubefirst and KubeStack
- **Format**: Matches existing entry style (`[Name](link) - Description`)